### PR TITLE
grafana: smtp setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@ NEX Jedi Team Hackathon Microservice project - Development Repo
 
 1. To build data export run `cd app-data-export` and run `make docker`
 
-2. To run the initial services, including the TIG stack, run `make run`
+2. To build sample service  run `cd app-sample-service` and run `make docker`
 
-3. **To run Bentoml pipelines-**
+3. To run the initial services, including the TIG stack, run `make run` under /team-jedi-hackathon-dev
+
+4. **To run Bentoml pipelines-**
 - You can run these commands directly on terminal, but to avoid any package environment issues, run them in a conda environment with python version 3.8 -
 - `conda create -n hackathon_env python=3.8`
 - `conda activate hackathon_env`

--- a/grafana/grafana.ini
+++ b/grafana/grafana.ini
@@ -34,3 +34,12 @@ default_home_dashboard_path = /etc/grafana/provisioning/dashboards/system-metric
 [auth.basic]
 # Note: disable grafana's built-in basic auth, as we are handling it with nginx
 enabled = false # was false before when working with edge
+
+[smtp]
+enabled=true
+host=smtp.gmail.com:587
+user=alertgrafanaemail@gmail.com
+password=qrxjykwcxlgoihth
+skip_verify=true
+from_address=alertgrafanaemail@gmail.com
+from_name=Grafana


### PR DESCRIPTION
- make run to bring up all services
- open grafana dashboard - `http://0.0.0.0:3001/grafana` (log in as admin, password is admin)
- Go to `Home/Alerting/Contact points`
- Edit the default contact point name, edit option will appear only if logged in as admin
- Under addresses text box provide - `alertgrafanaemail@gmail.com`, gmail created for demo which is set in grafana.ini
- Click Test
- While clicking `send test notification`, following success message should be displayed - `Test Alert Sent` (need to be outside vpn)